### PR TITLE
exposing common_handlers fixed in docs

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -24,7 +24,7 @@ from weppy import App, session
 from weppy.sessions import SessionCookieManager
 
 app = App(__name__)
-app.common_handlers = [SessionCookieManager('myverysecretkey')]
+app.expose.common_handlers = [SessionCookieManager('myverysecretkey')]
 
 @app.expose("/counter")
 # previous code


### PR DESCRIPTION
Took me quite some time to spot this while I debugged my own code ;).