### PR TITLE
Fixed _urlify function in Urlify validator, to make it work in python3

### DIFF
--- a/weppy/validators/process.py
+++ b/weppy/validators/process.py
@@ -61,7 +61,7 @@ class Urlify(Validator):
         # replace special characters
         s = unicodedata.normalize('NFKD', s)
         # encode as ASCII
-        s = s.encode('ascii', 'ignore')
+        s = s.encode('ascii', 'ignore').decode('ascii')
         # strip html entities
         s = re.sub('&\w+?;', '', s)
         if self.keep_underscores:


### PR DESCRIPTION
I've run into this problem, when I've tried to use urlify validator in my code:
```
  File "/home/hydesrv/.virtualenvs/weppy/lib/python3.5/site-packages/weppy/validators/process.py", line 66, in _urlify
    s = re.sub('&\w+?;', '', s)
  File "/home/hydesrv/.virtualenvs/weppy/lib/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: cannot use a string pattern on a bytes-like object
```