### PR TITLE
Fixing whitespace, tables, header issues

### DIFF
--- a/docs/app_and_modules.md
+++ b/docs/app_and_modules.md
@@ -26,15 +26,10 @@ Let's see the full parameters list in detail:
 
 | parameter | explanation |
 | --- | --- |
-| import_name | gives weppy an idea of what belongs to your application,
-usually using `__name__` will work out of the box, but you can hardcode 
-the name of your application package if you wish |
-| root_path | allows you to set a custom root path for your application,
-which is usually unnecessary |
-| template_folder | allows you to set a different folder for your application's
-templates (by default weppy uses the *templates* folder |
-| config_folder | allows you to set a different configuration folder for your 
-application, if you wish to load your configuration from files |
+| import_name | gives weppy an idea of what belongs to your application, usually using `__name__` will work out of the box, but you can hardcode the name of your application package if you wish |
+| root_path | allows you to set a custom root path for your application, which is usually unnecessary |
+| template_folder | allows you to set a different folder for your application's templates (by default weppy uses the *templates* folder |
+| config_folder | allows you to set a different configuration folder for your application, if you wish to load your configuration from files |
 
 Since we introduced the `config_folder` parameter, let's see some details
 about application configuration.
@@ -164,13 +159,10 @@ This is the complete list of parameters accepted by `AppModule`:
 | parameter | explaination |
 | --- | --- |
 | app | the weppy application to load module on |
-| name | name for the module, it will used by weppy as the namespace 
-for building URLs on internal routing |
+| name | name for the module, it will used by weppy as the namespace for building URLs on internal routing |
 | import_name | same as we seen for the `App` object |
-| template_folder | allows you to set a specific sub-folder of your 
-application template path for module templates |
-| template_path | allows you to set a specific folder inside your module root 
-path for module templates |
+| template_folder | allows you to set a specific sub-folder of your application template path for module templates |
+| template_path | allows you to set a specific folder inside your module root path for module templates |
 | url_prefix | allows you to set a prefix path for module URLs |
 | hostname | allows you to set a specific hostname for module |
 | root_path | same as we seen for the `App` object |

--- a/docs/debug_and_logging.md
+++ b/docs/debug_and_logging.md
@@ -4,8 +4,8 @@ Debug and logging
 *Errare humanum est*, said Seneca, a long time ago. As humans, sometimes we fail,
 and, sooner or later, we will see an exception on our applications. Even if the
 code is 100% correct, we can still get exceptions from time to time. And why? 
-Well, *shit happens*, not only as a consequence of the Finagle's Law&mdash;
-even if he was damn right, wasn't he?&mdash; but also because the process
+Well, *shit happens*, not only as a consequence of the Finagle's Law&mdash;even
+if he was damn right, wasn't he?&mdash;but also because the process
 of deploying web applications forces us to deal with a long list of involved
 technologies, everyone of which could fail. Just think about it: 
 the client may fail during the request, your database can be overloaded, 

--- a/docs/foreword.md
+++ b/docs/foreword.md
@@ -19,7 +19,7 @@ situation, less immediate; moreover, python is somewhat more *solid* than
 Ruby&mdash;maybe even too much solid. I think even Python would be advantaged by
 a more dynamic community: just think about Python 3's adoption status (Ed.).
 
-I really enjoyed writing code in Python, and after gaining some confidence,  
+I really enjoyed writing code in Python, and after gaining some confidence,
 I faced the second "big decision": which framework to use to write my 
 applications Looking at the Python scene, I (obviously) started looking at 
 *django*, the most famous one, but after a while I found I didn't like it. 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -61,8 +61,7 @@ Template structure
 Templates can extend other templates in a tree-like structure. For example, 
 we can think of a template *index.html* that extends *layout.html*.
 
-include
-~~~~~~~
+###include
 
 A structure like that would produce something like this for *index.html*:
 
@@ -91,8 +90,8 @@ recursive. When the template is parsed, the extended template is loaded,
 and the calling template replaces the `{{include}}` directive inside it.
 The contents of *footer.html* will be loaded inside the parent template.
 
-block
-~~~~~
+###block
+
 weppy templates have another important feature that accomplishes the same task
 as include, but in a different way: the `block` directive. Let's see how it
 works by updating the last example, with *index.html* looking like this:


### PR DESCRIPTION
The strange `<br />` in the `foreward.md` was caused by extra whitespace on the end of the line ending with "confidence," which seems absolutely bizarre to me because it is inherently *invisible* markup. That's not even WYSIWYG, because you *can't see it*.

I've fixed the tables, and noticed another problem with some separation headers in `templates.md`. Terribly sorry for these mistakes.