### PR TITLE
added custom filename name option

### DIFF
--- a/weppy/expose.py
+++ b/weppy/expose.py
@@ -138,7 +138,7 @@ class Expose(object):
 
     def __call__(self, func):
         self.func_name = func.__name__
-        self.filename = getattr(func, 'custom_name', None) or os.path.realpath(func.__code__.co_filename)
+        self.filename = func.__dict__.get('custom_name') or os.path.realpath(func.__code__.co_filename)
         #self.mtime = os.path.getmtime(self.filename)
         self.hostname = self.hostname or \
             self.application.config.hostname_default

--- a/weppy/expose.py
+++ b/weppy/expose.py
@@ -138,7 +138,7 @@ class Expose(object):
 
     def __call__(self, func):
         self.func_name = func.__name__
-        self.filename = os.path.realpath(func.__code__.co_filename)
+        self.filename = getattr(func, 'custom_name', None) or os.path.realpath(func.__code__.co_filename)
         #self.mtime = os.path.getmtime(self.filename)
         self.hostname = self.hostname or \
             self.application.config.hostname_default


### PR DESCRIPTION
allows you to write custom decorators to be placed before the @app.route. example:

@app.route()
@custom_dec
def myRoute():
    return 200

without the custom_name option, the route takes on the name of the file custom_dec is defined in. I've tried a bunch of other things, but this seems to be the only thing that works. Just for more clarity, the problem I'm facing is this:

in main.py:

@app.route()
def myRoute():
    return 200

Awesome, perfectly fine. and I'd reference it with url('main.myRoute') to be explicit. Now I'm writing a weppy extension which provides additional decorators, e.g. custom_dec() so now:

in main.py:

from myExtension import custom_dec

@app.route()
@custom_dec
def myRoute():
    return 200

and in myExtension.py:

def custom_dec(fn):
    @functools.wraps(fn):
    def wrapper(*args, **kwargs):
        ...function wrapper...
    return wrapper

Now, I instead of referencing by url('main.myRoute'), it's now url('myExtension.myRoute') because wrapper is defined in myExtension.py. And that's what my commit tries to avoid: breaking user space. So now I can do this in myExtension.py:

def custom_dec(fn):
    @functools.wraps(fn):
    def wrapper(*args, **kwargs):
        ...function wrapper...
    wrapper.\_\_dict__['custom_name'] = 'main'
    return wrapper

and I can now still reference it with url('main.myRoute')

Or maybe I'm totally noob-sauce and this is totally not what I'm supposed to do, let me know!