### PR TITLE
Fix regex url matching case

### DIFF
--- a/weppy/expose.py
+++ b/weppy/expose.py
@@ -90,6 +90,8 @@ class Expose(object):
         path = cls.REGEX_ANY.sub('(?P<\g<1>>.*)', path)
         path = cls.REGEX_ALPHA.sub('(?P<\g<1>>[^/\W\d_]+)', path)
         path = cls.REGEX_DATE.sub('(?P<\g<1>>\d{4}-\d{2}-\d{2})', path)
+        if path is not '/':
+            path += '(/?)'
         re_schemes = ('|'.join(schemes)).lower()
         re_methods = ('|'.join(methods)).lower()
         re_hostname = re.escape(hostname) if hostname else '[^/]*'
@@ -200,7 +202,7 @@ class Expose(object):
 
     @classmethod
     def match(cls, request):
-        path = cls.remove_trailslash(request.path_info)
+        path = request.path_info
         if cls.application.language_force_on_url:
             path, lang = cls.match_lang(path)
             request.language = lang


### PR DESCRIPTION
Hello,

I was trying the regex url matching example. I was not able to match empty parameter case i.e `http:127.0.0.1:8000/profile/`. This case was failing because` /` was getting stripped from the url. This fix addresses the problem. This fix handles both `/profile/1` and `profile/1/`.

Also the regex syntax seems to be wrong in the documentation. I will fix the documentation in separate pull request.

```
@app.route("/profile(/<int:user_id>)?")
def profile(user_id):
    if user_id:
        # get requested user
    else:
        # load current logged user profile
```