### PR TITLE
Fix migrations primary_key generation

### DIFF
--- a/weppy/dal/migrations/engine.py
+++ b/weppy/dal/migrations/engine.py
@@ -135,9 +135,9 @@ class Engine(MetaEngine):
 
     def _gen_primary_key(self, fields, primary_keys=[]):
         if primary_keys:
-            fields.append(self.db.PRIMARY_KEY(
+            fields.append(self.adapter.PRIMARY_KEY(
                 ', '.join([
-                    self.db.QUOTE_TEMPLATE % pk for pk in primary_keys])))
+                    self.adapter.QUOTE_TEMPLATE % pk for pk in primary_keys])))
 
     def _gen_geo(self, tablename, column):
         if not hasattr(self.adapter, 'srid'):


### PR DESCRIPTION
I was trying to create tables with migrations and got this error on primary key generation:

```
  File "/weppy/weppy/dal/migrations/engine.py", line 138, in _gen_primary_key
    fields.append(self.db.PRIMARY_KEY(
  File "/weppy-app/env/lib/python2.7/site-packages/pydal/base.py", line 921, in __getattr__
    return BasicStorage.__getattribute__(self, key)
AttributeError: 'DAL' object has no attribute 'PRIMARY_KEY'
```

`PRIMARY_KEY` is not defined on `self.db` but in `self.db._adapter`.