### PR TITLE
Fix install_requires syntax in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'click>=0.6',
+        'click >= 0.6',
         'pyaes',
         'pyDAL==16.9',
         'pyyaml',


### PR DESCRIPTION
Would not install (on Python 2.7 at least) unless this change was made