### PR TITLE
Fix typo in patterns.md example

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -152,7 +152,7 @@ from weppy import App
 from weppy.orm import Database
 
 app = App(__name__)
-app.url_default_namespace = "main"
+app.config.url_default_namespace = "main"
 
 db = Database()
 


### PR DESCRIPTION
`url_default_namespace` is a property of the `app.config`, and not of the `App` object itself. This minor error in the documentation could lead to some confusion for developers trying to follow the MVC-style package structure.